### PR TITLE
Bump bolt to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "bolt": "^0.19.3",
+    "bolt": "^0.24.4",
     "globby": "^6.1.0",
     "parse-json": "^3.0.0",
     "typeable-promisify": "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,17 +325,21 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bolt@^0.19.3:
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/bolt/-/bolt-0.19.3.tgz#313d9e0924129b9b9493187bf0d312e13af1c253"
+bolt@^0.24.4:
+  version "0.24.4"
+  resolved "https://registry.yarnpkg.com/bolt/-/bolt-0.24.4.tgz#0b6080b8dff84415f194e6e3067e9361042f3514"
+  integrity sha512-Y4adoDkT/HtdlGWaMM35qi7JV30dAGCyseNnUvKT5BJVlsBODMOCEkNLTDtKwtyuCuUhWaDdIuLwYQgW8HdMlw==
   dependencies:
     array-includes "^3.0.3"
     babel-runtime "^6.25.0"
     chalk "^2.0.1"
+    chunkd "^1.0.0"
+    ci-parallel-vars "^1.0.0"
     clean-stack "^1.3.0"
     cmd-shim "^2.0.2"
     cross-spawn "^5.1.0"
     detect-indent "^5.0.0"
+    detect-newline "2.1.0"
     find-up "^2.1.0"
     globby "^6.1.0"
     inquirer "3.3.0"
@@ -358,7 +362,7 @@ bolt@^0.19.3:
     task-graph-runner "^1.0.1"
     temp-write "^3.4.0"
     typeable-promisify "^2.0.1"
-    yarn "^1.3.2"
+    yarn "^1.9.4"
 
 boom@2.x.x:
   version "2.10.1"
@@ -473,9 +477,19 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+chunkd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chunkd/-/chunkd-1.0.0.tgz#4ead4a3704bcce510c4bb4d4a8be30c557836dd1"
+  integrity sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==
+
 ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
+
+ci-parallel-vars@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz#af97729ed1c7381911ca37bcea263d62638701b3"
+  integrity sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==
 
 clean-stack@^1.3.0:
   version "1.3.0"
@@ -645,6 +659,11 @@ detect-indent@^4.0.0:
 detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
+
+detect-newline@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
 diff@^3.2.0:
   version "3.3.0"
@@ -2710,6 +2729,7 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn@^1.3.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.5.1.tgz#e8680360e832ac89521eb80dad3a7bc27a40bab4"
+yarn@^1.9.4:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.0.tgz#acf82906e36bcccd1ccab1cfb73b87509667c881"
+  integrity sha512-KMHP/Jq53jZKTY9iTUt3dIVl/be6UPs2INo96+BnZHLKxYNTfwMmlgHTaMWyGZoO74RI4AIFvnWhYrXq2USJkg==


### PR DESCRIPTION
Primary reason is to consume this change that ignores workspaces with
missing package.json: https://github.com/boltpkg/bolt/commit/cb41cd0572a037584b3822a7a7cf73e2dce80310